### PR TITLE
Adapt to text-decoration-skip spec change

### DIFF
--- a/src/layouts/index.css
+++ b/src/layouts/index.css
@@ -58,7 +58,7 @@ html {
 a {
   color: var(--text);
 
-  text-decoration-skip: ink;
+  text-decoration-skip-ink: auto;
 }
 
 blockquote {


### PR DESCRIPTION
Suppress warning, because the `text-decoration-skip: ink` value was moved to the `text-decoration-skip-ink: auto` property.