### PR TITLE
Update gatsby-node.js typo

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -30,7 +30,7 @@ exports.onCreatePage = ({ page, actions }) => {
 // Create pages from markdown nodes
 exports.createPages = ({ actions, createNodeId, graphql }) => {
   const { createPage, createNode } = actions;
-  const blogPostTemplate = path.resolve(`src/templates/slide.js`);
+  const slideTemplate = path.resolve(`src/templates/slide.js`);
 
   return graphql(`
     {
@@ -76,7 +76,7 @@ exports.createPages = ({ actions, createNodeId, graphql }) => {
     nodes.forEach((slide, index) => {
       createPage({
         path: `/${index + 1}`,
-        component: blogPostTemplate,
+        component: slideTemplate,
         context: {
           index: index + 1,
           absolutePath: process.cwd() + `/src/slides#${index + 1}`,


### PR DESCRIPTION
`blogPostTemplate` -> `slideTemplate`. Probably a left over from using the blog template, makes more sense in this context to be `slideTemplate` as we're dealing with `slides` not `blogPosts`! 😄